### PR TITLE
Datetime-Picker available in browser language and .gitignore for node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -118,7 +118,6 @@ class Widget extends Component {
       <DateTimePicker
         onChange={this.changeDateTime}
         value={this.state.countdownDateTime}
-        locale={'RU-RU'}
       />
       <Panel className={styles.formFooter}>
         <Button


### PR DESCRIPTION
I really like this small widget for a countdown to our next release at @cioplenu but I always get a little confused by the only Russian date picker. Is there a reason for being set fixed to Russian? If not this is a small PR setting it to the browsers default language.

I also added the `node_module` file to the `.gitignore` because my code editor was complaining about that but I can remove it again, if you don't want to have a `.gitignore`.